### PR TITLE
Fix last read date being reset when checking for updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/services/DownloaderFactory.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/services/DownloaderFactory.java
@@ -313,30 +313,33 @@ class DownloaderFactory {
 			// By default, the Story object has a date added equal to 0 upon creation. If this value
 			// is found, then the story is newly added and the date added should be set to the current
 			// date. Otherwise, the date added should be conserved.
-			final Date dateDownloaded;
+			final Date dateDownloaded, dateLastRead;
 			final ContentResolver resolver = mContext.getContentResolver();
 			final Cursor c = resolver.query(StoryProvider.FF_CONTENT_URI,
-											new String[] { SqlConstants.KEY_ADDED },
+											new String[] { SqlConstants.KEY_ADDED, SqlConstants.KEY_LAST_READ },
 											SqlConstants.KEY_STORY_ID + " = ?",
 											new String[] { String.valueOf(mStoryId) }, null);
 
 			if (c == null){
 				// Validate the cursor
 				dateDownloaded = null;
+				dateLastRead = null;
 			} else if (!c.moveToFirst()) {
 				// Check that the cursor is not empty
 				c.close();
 				dateDownloaded = null;
+				dateLastRead = null;
 			} else{
 				// Determine the last time the story was updated
-				final int index = c.getColumnIndex(SqlConstants.KEY_ADDED);
-				dateDownloaded = new Date(c.getLong(index));
+				dateDownloaded = new Date(c.getLong(c.getColumnIndex(SqlConstants.KEY_ADDED)));
+				dateLastRead = new Date(c.getLong(c.getColumnIndex(SqlConstants.KEY_LAST_READ)));
 				c.close();
 			}
-			final Date dateAdded = (dateDownloaded != null ? dateDownloaded : new Date());
+			final Date dateAdded = (dateDownloaded != null ? dateDownloaded : new Date()),
+					dateRead = (dateLastRead != null ? dateLastRead : new Date(0));
 
 			// Update the content provider
-			resolver.insert(StoryProvider.FF_CONTENT_URI, mStory.toContentValues(lastPageRead, scrollOffset, dateAdded));
+			resolver.insert(StoryProvider.FF_CONTENT_URI, mStory.toContentValues(lastPageRead, scrollOffset, dateAdded, dateRead));
 		}
 
 		@Override

--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/util/Story.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/util/Story.java
@@ -71,7 +71,7 @@ public class Story implements Parcelable, SqlConstants {
 		return builder.build();
 	}
 
-	public ContentValues toContentValues(int lastPage, int offset, Date added) {
+	public ContentValues toContentValues(int lastPage, int offset, Date added, Date lastRead) {
 		ContentValues v = new ContentValues();
 		v.put(KEY_STORY_ID, id);
 		v.put(KEY_TITLE, name);


### PR DESCRIPTION
This changes DownloaderFactory to preserve the Last Read field when a story is updated (including when checking for updates).

This should fix issue #32.