### PR TITLE
scroll story screen up/down by keyboard / gestures 

### DIFF
--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/activity/reader/StoryDisplayActivity.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/activity/reader/StoryDisplayActivity.java
@@ -164,15 +164,32 @@ public class StoryDisplayActivity extends AppCompatActivity implements LoaderCal
 		// scroll page up / down by keyboard.
 		// Support slash / backslash as additional keys because
 		// for many tablet keyboards, pressing page up/down requires additional Fn key
-		switch(keyCode) {
-			case KeyEvent.KEYCODE_PAGE_DOWN:
-			case KeyEvent.KEYCODE_BACKSLASH:
-				scrollStoryByPage(PGDN);
-				return true;
-			case KeyEvent.KEYCODE_PAGE_UP:
-			case KeyEvent.KEYCODE_SLASH:
-				scrollStoryByPage(PGUP);
-				return true;
+		if (event.hasNoModifiers()) {
+			switch (keyCode) {
+				case KeyEvent.KEYCODE_PAGE_DOWN:
+				case KeyEvent.KEYCODE_BACKSLASH:
+					scrollStoryByPage(PGDN);
+					return true;
+				case KeyEvent.KEYCODE_PAGE_UP:
+				case KeyEvent.KEYCODE_SLASH:
+					scrollStoryByPage(PGUP);
+					return true;
+			}
+		}
+
+		if (event.isShiftPressed()) {
+			switch (keyCode) {
+				case KeyEvent.KEYCODE_DPAD_RIGHT:
+					if (mCurrentPage < mTotalPages) {
+						load(mCurrentPage + 1);
+					}
+					return true;
+				case KeyEvent.KEYCODE_DPAD_LEFT:
+					if (mCurrentPage > 1) {
+						load(mCurrentPage - 1);
+					}
+					return true;
+			}
 		}
 
 		return super.onKeyDown(keyCode, event);


### PR DESCRIPTION
closes #37 

Allow users to scroll story screen page up / down with
1. keyboard: `PageUp` or `/`  and `PageDown` or `\`
2. gesture: swipe left / right at screen bottom

Note: Use of `/`, `\` keys for page up / down is to support smaller keyboards where PageUp/Down keys require additional `Fn`. It might need to be user-configurable.