### PR TITLE
#50 - further tweak on story display fullscreen mode on edge cases.

### DIFF
--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/activity/reader/StoryDisplayActivity.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/activity/reader/StoryDisplayActivity.java
@@ -56,7 +56,6 @@ import com.spicymango.fanfictionreader.util.Sites;
 import com.spicymango.fanfictionreader.util.adapters.TextAdapter;
 
 import org.jsoup.Connection.Method;
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -626,8 +625,8 @@ public class StoryDisplayActivity extends AppCompatActivity implements LoaderCal
 	}
 
 	@Override
-	protected void onStart() {
-		super.onStart();
+	protected void onResume() {
+		super.onResume();
 		final int visibility = getWindow().getDecorView().getSystemUiVisibility();
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 			int newVisibility = visibility


### PR DESCRIPTION
Related to #50 

- it fixes the edge cases after some transparent apps overlay on top of the app, e.g., launched from notifications / quick settings, the story display will exit fullscreen mode.
