### PR TITLE
Customized settings from Story screen: a simplified / customized settings

### DIFF
--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/Settings.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/Settings.java
@@ -1,11 +1,5 @@
 package com.spicymango.fanfictionreader;
 
-import com.spicymango.fanfictionreader.dialogs.backup.BackUpDialog;
-import com.spicymango.fanfictionreader.dialogs.FontDialog;
-import com.spicymango.fanfictionreader.dialogs.backup.RestoreDialog;
-import com.spicymango.fanfictionreader.dialogs.backup.RestoreDialogConfirmation;
-import com.spicymango.fanfictionreader.util.FileHandler;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
@@ -21,7 +15,9 @@ import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
+import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
+import android.preference.PreferenceScreen;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.preference.PreferenceFragment;
@@ -29,6 +25,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.DisplayMetrics;
 import android.view.MenuItem;
 
+import com.spicymango.fanfictionreader.dialogs.FontDialog;
+import com.spicymango.fanfictionreader.dialogs.backup.BackUpDialog;
+import com.spicymango.fanfictionreader.dialogs.backup.RestoreDialog;
+import com.spicymango.fanfictionreader.dialogs.backup.RestoreDialogConfirmation;
+import com.spicymango.fanfictionreader.util.FileHandler;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 
@@ -36,6 +40,7 @@ public class Settings extends AppCompatActivity {
 
 	public final static int SANS_SERIF = 0;
 	public final static int SERIF = 1;
+	public static final String EXTRA_READER_SETTINGS = "READER_SETTINGS";
 
 	/**
 	 * An enum for the old text size format, before it was customizable. Retained only for
@@ -115,6 +120,24 @@ public class Settings extends AppCompatActivity {
 			// Check if the font button is clicked
 			final Preference fontDialog = findPreference(getString(R.string.pref_key_text_size));
 			fontDialog.setOnPreferenceClickListener(this);
+
+			if (getActivity().getIntent().getBooleanExtra(EXTRA_READER_SETTINGS, false)) {
+				customizeUIAsReaderSetting();
+			}
+		}
+
+		private void customizeUIAsReaderSetting() {
+			final PreferenceScreen ps = getPreferenceScreen();
+			List<Preference> prefsToRemove = new ArrayList<>(ps.getPreferenceCount() -1);
+			for(int i = 1; i < ps.getPreferenceCount(); i++) { // leave the first (Appearance) intact
+				prefsToRemove.add(ps.getPreference(i));
+			}
+			for (Preference pref : prefsToRemove) {
+				ps.removePreference(pref);
+			}
+
+			PreferenceGroup pgAppearance = ((PreferenceGroup)ps.getPreference(0));
+			pgAppearance.removePreference(pgAppearance.findPreference(getString(R.string.pref_key_locale)));
 		}
 
 		@Override

--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/activity/reader/StoryDisplayActivity.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/activity/reader/StoryDisplayActivity.java
@@ -56,7 +56,6 @@ import com.spicymango.fanfictionreader.util.Sites;
 import com.spicymango.fanfictionreader.util.adapters.TextAdapter;
 
 import org.jsoup.Connection.Method;
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -331,6 +330,7 @@ public class StoryDisplayActivity extends AppCompatActivity implements LoaderCal
 			return true;
 		case R.id.reader_settings:
 			Intent intent = new Intent(this, Settings.class);
+			intent.putExtra(Settings.EXTRA_READER_SETTINGS, true);
 			startActivityForResult(intent, INTENT_SETTINGS);
 			return true;
 		case R.id.read_story_go_to:


### PR DESCRIPTION
It is more on #52. 
- tailored settings UI for story screen, with appearance related settings only (see screenshot)
- It is done by programmatically hiding the rest of settings. I am of two minds whether this is advisable.

<img width="384" height="640" src="https://user-images.githubusercontent.com/250644/53704598-e2435200-3dd2-11e9-8df4-e67b0a831775.png">


