### PR TITLE
Made Library downloader use foregroundSerivce

### DIFF
--- a/fanfictionReader/src/main/AndroidManifest.xml
+++ b/fanfictionReader/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
 
     <application
         android:name=".FanFictionApplication"

--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/services/LibraryDownloader.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/services/LibraryDownloader.java
@@ -84,6 +84,11 @@ public class LibraryDownloader extends IntentService {
 	 */
 	private final static int NOTIFICATION_DOWNLOAD_ID = 1;
 
+	/**
+	 * ID For the required foreground notification
+	 */
+	private final static int NOTIFICATION_FOREGROUND_ID =  3;
+
 	private final static String NOTIFICATION_CHANNEL = "Channel";
 
 	/**
@@ -130,7 +135,11 @@ public class LibraryDownloader extends IntentService {
 		i.setData(uri);
 		i.putExtra(EXTRA_LAST_PAGE, currentPage);
 		i.putExtra(EXTRA_OFFSET, offset);
-		context.startService(i);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			context.startForegroundService(i);
+		} else {
+			context.startService(i);
+		}
 	}
 
 	/**
@@ -173,6 +182,8 @@ public class LibraryDownloader extends IntentService {
 																  NotificationManager.IMPORTANCE_LOW);
 			final NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 			manager.createNotificationChannel(channel);
+			NotificationCompat.Builder builder = new NotificationCompat.Builder(LibraryDownloader.this, NOTIFICATION_CHANNEL);
+			startForeground(NOTIFICATION_FOREGROUND_ID, builder.build());
 		}
 	}
 


### PR DESCRIPTION
Fix regression where newer versions of android would kill the librarydownloader when the app wasn't in the foreground. This was fixed by making the librarydownloader service a foreground service so it would n't try kill the service so often to reclaim system resources. 