### PR TITLE
dont cancel request if an ad fails to load

### DIFF
--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/menu/CloudflareFragment.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/menu/CloudflareFragment.java
@@ -165,7 +165,9 @@ public class CloudflareFragment extends Fragment {
 		public void onReceivedError(WebView view, WebResourceRequest request,
 									WebResourceError error) {
 			super.onReceivedError(view, request, error);
-			closeFragment("404");
+			if (!request.getUrl().toString().contains("pagead")) {
+				closeFragment("404");
+			}
 		}
 
 		@Override

--- a/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/services/DownloaderFactory.java
+++ b/fanfictionReader/src/main/java/com/spicymango/fanfictionreader/services/DownloaderFactory.java
@@ -536,9 +536,11 @@ class DownloaderFactory {
 										WebResourceError error) {
 				super.onReceivedError(view, request, error);
 
-				mHtmlFromWebView = "404";
-				synchronized (mutex) {
-					mutex.notify();
+				if (!request.getUrl().toString().contains("pagead")) {
+					mHtmlFromWebView = "404";
+					synchronized (mutex) {
+						mutex.notify();
+					}
 				}
 			}
 


### PR DESCRIPTION
If ad blocking is in place on the device or network, trying to load any page that contains an add will currently trigger a "Failed to connect to server" because the network error of the blocked ad will be seen as a failure to load the page.

This is a **very** hacky workaround and something more reliable for detecting when an error can be ignored should probably be created. But it is enough to make things work for me™ for now.